### PR TITLE
feat: Add Action class for Road Runner

### DIFF
--- a/MeepMeepTesting/src/main/java/com/example/meepmeeptesting/SampleSideAuto.java
+++ b/MeepMeepTesting/src/main/java/com/example/meepmeeptesting/SampleSideAuto.java
@@ -16,12 +16,13 @@ public class SampleSideAuto {
                 .build();
 
         myBot.runAction(myBot.getDrive().actionBuilder(new Pose2d(11.5, -61.5, Math.toRadians(90)))
-//                        .strafeTo(new Vector2d(36,-61.5))
+                .strafeTo(new Vector2d(7,-37))
+                .strafeTo(new Vector2d(11.5,-40))
 
 //                .splineTo(new Vector2d(40,0),Math.toRadians(90))
 //                        .lineToY(-48)
-                           .splineTo(new Vector2d(36,-36),Math.toRadians(90))
-                           .splineTo(new Vector2d(36,0),Math.toRadians(90))
+                           .splineToConstantHeading(new Vector2d(36,-36),Math.toRadians(90))
+                           .splineToConstantHeading(new Vector2d(36,0),Math.toRadians(90))
                            .strafeTo(new Vector2d(42,0))
                            .strafeTo(new Vector2d(42,-50)) // first sample into obervation zone
                            .strafeTo(new Vector2d(42,0))

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Action.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Action.java
@@ -129,7 +129,8 @@ public class Action {
 		telemetry.update();
 	}
 
-	public class Claw implements com.acmerobotics.roadrunner.Action {@Override
+	public class Claw implements com.acmerobotics.roadrunner.Action {
+		@Override
 		public boolean run(@NonNull TelemetryPacket packet) {
 			claw.setPosition(clawTarget);
 			packet.put("Claw Target", clawTarget);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Action.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Action.java
@@ -1,0 +1,149 @@
+package org.firstinspires.ftc.teamcode.Actions;
+
+import androidx.annotation.NonNull;
+
+import com.acmerobotics.dashboard.FtcDashboard;
+import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
+import com.acmerobotics.dashboard.telemetry.TelemetryPacket;
+import com.arcrobotics.ftclib.controller.PIDFController;
+import com.arcrobotics.ftclib.hardware.motors.Motor;
+import com.arcrobotics.ftclib.hardware.motors.MotorGroup;
+import com.arcrobotics.ftclib.util.Timing;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+import com.qualcomm.robotcore.hardware.PIDFCoefficients;
+import com.qualcomm.robotcore.hardware.Servo;
+
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+
+public class Action {
+	private final MotorGroup liftMotor;
+	private final Motor shoulder;
+	private final Servo claw;
+	private final Servo wrist;
+	private final PIDFCoefficients liftCoefficients = new PIDFCoefficients(0.025, 0, 0, 0.0006);
+	private final PIDFController liftController = new PIDFController(liftCoefficients.p, liftCoefficients.i, liftCoefficients.d, liftCoefficients.f);
+	private final PIDFCoefficients shoulderCoefficients = new PIDFCoefficients(0.037, 0, 0, 0.001);
+	private final PIDFController shoulderController = new PIDFController(shoulderCoefficients.p, shoulderCoefficients.i, shoulderCoefficients.d, shoulderCoefficients.f);
+	private double clawTarget = 0;
+	private double wristTarget = 0;
+	private double liftTarget = 0;
+	private double shoulderTarget = 0;
+	private final MultipleTelemetry telemetry;
+	private Timing.Timer holdTimer;
+
+	public Action(HardwareMap hardwareMap, Telemetry originalTelemetry) {
+		Motor liftMotorLeft = new Motor(hardwareMap, "liftMotorLeft", Motor.GoBILDA.RPM_117);
+		Motor liftMotorRight = new Motor(hardwareMap, "liftMotorRight", Motor.GoBILDA.RPM_117);
+		liftMotor = new MotorGroup(liftMotorLeft, liftMotorRight);
+		shoulder = new Motor(hardwareMap, "shoulder", 2759.12, 60.89);
+		claw = hardwareMap.get(Servo.class, "claw");
+		wrist = hardwareMap.get(Servo.class, "wrist");
+
+		double liftTolerance = 0.5;
+		liftController.setTolerance(liftTolerance);
+		double shoulderTolerance = 1.8;
+		shoulderController.setTolerance(shoulderTolerance);
+
+		liftMotor.setInverted(false);
+		shoulder.setInverted(true);
+		claw.scaleRange(0, 1);
+		wrist.scaleRange(0, 1);
+		liftMotor.resetEncoder();
+		shoulder.resetEncoder();
+		liftMotor.setRunMode(Motor.RunMode.RawPower);
+		shoulder.setRunMode(Motor.RunMode.RawPower);
+
+		telemetry = new MultipleTelemetry(originalTelemetry, FtcDashboard.getInstance().getTelemetry());
+	}
+
+	public Lift lift(double inches) {
+		double liftTicksPerInch = 1;
+		liftTarget = inches * liftTicksPerInch;
+		return new Lift();
+	}
+
+	public Shoulder shoulder(double degrees) {
+		double shoulderTicksPerDegree = 1;
+		shoulderTarget = degrees * shoulderTicksPerDegree;
+		return new Shoulder();
+	}
+
+	public Claw claw(double target) {
+		clawTarget = target;
+		return new Claw();
+	}
+
+	public Wrist wrist(double target) {
+		wristTarget = target;
+		return new Wrist();
+	}
+
+	public Hold hold(double waitTime) {
+		holdTimer = new Timing.Timer((long) waitTime);
+		holdTimer.start();
+		return new Hold();
+	}
+
+	public class Lift implements com.acmerobotics.roadrunner.Action {
+		@Override
+		public boolean run(@NonNull TelemetryPacket packet) {
+			moveAndHold();
+
+			return !liftController.atSetPoint();
+		}
+	}
+
+	public class Shoulder implements com.acmerobotics.roadrunner.Action {
+		@Override
+		public boolean run(@NonNull TelemetryPacket packet) {
+			moveAndHold();
+
+			return !shoulderController.atSetPoint();
+		}
+	}
+
+	public class Hold implements com.acmerobotics.roadrunner.Action {
+		@Override
+		public boolean run(@NonNull TelemetryPacket packet) {
+			moveAndHold();
+
+			return holdTimer.done();
+		}
+	}
+
+	private void moveAndHold() {
+		double currentLiftPosition = liftMotor.getCurrentPosition();
+		double liftPidOutput = liftController.calculate(currentLiftPosition, liftTarget);
+		liftMotor.set(liftPidOutput);
+
+		double currentShoulderPosition = shoulder.getCurrentPosition();
+		double shoulderPidOutput = shoulderController.calculate(currentShoulderPosition, shoulderTarget);
+		shoulder.set(shoulderPidOutput);
+
+		telemetry.addData("Lift Target Ticks", liftTarget);
+		telemetry.addData("Lift Current Ticks", currentLiftPosition);
+		telemetry.addData("Lift Motor Power", liftPidOutput);
+		telemetry.addData("Shoulder Target Ticks", shoulderTarget);
+		telemetry.addData("Shoulder Current Ticks", currentShoulderPosition);
+		telemetry.addData("Shoulder Motor Power", shoulderPidOutput);
+		telemetry.update();
+	}
+
+	public class Claw implements com.acmerobotics.roadrunner.Action {@Override
+		public boolean run(@NonNull TelemetryPacket packet) {
+			claw.setPosition(clawTarget);
+			packet.put("Claw Target", clawTarget);
+
+			return true;
+		}
+	}
+
+	public class Wrist implements com.acmerobotics.roadrunner.Action {@Override
+		public boolean run(@NonNull TelemetryPacket packet) {
+			wrist.setPosition(wristTarget);
+			packet.put("Wrist Target", wristTarget);
+
+			return true;
+		}
+	}
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Action.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Action.java
@@ -63,7 +63,7 @@ public class Action {
 	}
 
 	public Shoulder shoulder(double degrees) {
-		double shoulderTicksPerDegree = 1;
+		double shoulderTicksPerDegree = 22.755;
 		shoulderTarget = degrees * shoulderTicksPerDegree;
 		return new Shoulder();
 	}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Action.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Action.java
@@ -35,7 +35,7 @@ public class Action {
 		Motor liftMotorLeft = new Motor(hardwareMap, "liftMotorLeft", Motor.GoBILDA.RPM_117);
 		Motor liftMotorRight = new Motor(hardwareMap, "liftMotorRight", Motor.GoBILDA.RPM_117);
 		liftMotor = new MotorGroup(liftMotorLeft, liftMotorRight);
-		shoulder = new Motor(hardwareMap, "shoulder", 2759.12, 60.89);
+		shoulder = new Motor(hardwareMap, "shoulder");
 		claw = hardwareMap.get(Servo.class, "claw");
 		wrist = hardwareMap.get(Servo.class, "wrist");
 
@@ -129,7 +129,8 @@ public class Action {
 		telemetry.update();
 	}
 
-	public class Claw implements com.acmerobotics.roadrunner.Action {@Override
+	public class Claw implements com.acmerobotics.roadrunner.Action {
+		@Override
 		public boolean run(@NonNull TelemetryPacket packet) {
 			claw.setPosition(clawTarget);
 			packet.put("Claw Target", clawTarget);
@@ -138,7 +139,8 @@ public class Action {
 		}
 	}
 
-	public class Wrist implements com.acmerobotics.roadrunner.Action {@Override
+	public class Wrist implements com.acmerobotics.roadrunner.Action {
+		@Override
 		public boolean run(@NonNull TelemetryPacket packet) {
 			wrist.setPosition(wristTarget);
 			packet.put("Wrist Target", wristTarget);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Arm.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Arm.java
@@ -15,13 +15,13 @@ public class Arm implements Action {
 	private final double target;
 	private final PIDController controller;
 	public final DcMotor shoulder;
-	private final static double ticksPerDegree = (double) 1;
+	private final static double ticksPerDegree = 22.755;
 	private final double f;
 
 	public Arm(HardwareMap hw, double target) {
 		this.target = target * ticksPerDegree;
 
-		// retuned for through bore encoder
+		// re-tuned for through bore encoder
 		PIDFCoefficients pidfCoefficients = new PIDFCoefficients(0.0009, 0, 0.0001, 0.0005);
 		controller = new PIDController(pidfCoefficients.p, pidfCoefficients.i, pidfCoefficients.d);
 		controller.setTolerance(1.8 * ticksPerDegree);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Arm.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Arm.java
@@ -22,7 +22,7 @@ public class Arm implements Action {
 		this.target = target * ticksPerDegree;
 
 		// retuned for through bore encoder
-		PIDFCoefficients pidfCoefficients = new PIDFCoefficients(0.00108, 0, 0.00001, 0.2);
+		PIDFCoefficients pidfCoefficients = new PIDFCoefficients(0.0009, 0, 0.0001, 0.0005);
 		controller = new PIDController(pidfCoefficients.p, pidfCoefficients.i, pidfCoefficients.d);
 		controller.setTolerance(1.8 * ticksPerDegree);
 		f = pidfCoefficients.f;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Arm.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Arm.java
@@ -20,7 +20,9 @@ public class Arm implements Action {
 
 	public Arm(HardwareMap hw, double target) {
 		this.target = target * ticksPerDegree;
-		PIDFCoefficients pidfCoefficients = new PIDFCoefficients(0.037, 0, 0, 0.001);
+
+		// retuned for through bore encoder
+		PIDFCoefficients pidfCoefficients = new PIDFCoefficients(0.00108, 0, 0.00001, 0.2);
 		controller = new PIDController(pidfCoefficients.p, pidfCoefficients.i, pidfCoefficients.d);
 		controller.setTolerance(1.8 * ticksPerDegree);
 		f = pidfCoefficients.f;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Lift.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Actions/Lift.java
@@ -8,7 +8,6 @@ import com.acmerobotics.roadrunner.Action;
 import com.arcrobotics.ftclib.controller.PIDFController;
 import com.arcrobotics.ftclib.hardware.motors.Motor;
 import com.arcrobotics.ftclib.hardware.motors.MotorGroup;
-import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.PIDFCoefficients;
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version2/RoadRunnerMoveTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version2/RoadRunnerMoveTest.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.OpModes.Autonomous.Tests;
+package org.firstinspires.ftc.teamcode.OpModes.Autonomous.Tests.Version2;
 
 import com.acmerobotics.roadrunner.Pose2d;
 import com.acmerobotics.roadrunner.Vector2d;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version2/RoadrunnerArmTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version2/RoadrunnerArmTest.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.OpModes.Autonomous.Tests;
+package org.firstinspires.ftc.teamcode.OpModes.Autonomous.Tests.Version2;
 
 import com.acmerobotics.dashboard.FtcDashboard;
 import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
@@ -7,7 +7,6 @@ import com.acmerobotics.roadrunner.SleepAction;
 import com.acmerobotics.roadrunner.ftc.Actions;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
-import com.qualcomm.robotcore.hardware.PIDFCoefficients;
 
 import org.firstinspires.ftc.teamcode.Actions.Arm;
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version2/RoadrunnerArmTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version2/RoadrunnerArmTest.java
@@ -68,18 +68,18 @@ public class RoadrunnerArmTest extends OpMode {
 		if(id == 1)
 		{
 			currentAction =  new SequentialAction(
-					new Arm(hardwareMap, 800),
+					new Arm(hardwareMap, 45),
 //					new Arm(hardwareMap, 500),
-					new Arm(hardwareMap, 300)
+					new Arm(hardwareMap, 15)
 			);
 		}
 		else if(id == 2)
 		{
 			currentAction =  new SequentialAction(
-					new Arm(hardwareMap, 300),
-					new Arm(hardwareMap, 500),
+					new Arm(hardwareMap, 15),
+					new Arm(hardwareMap, 30),
 					new SleepAction(3),
-					new Arm(hardwareMap, 800)
+					new Arm(hardwareMap, 45)
 			);
 		}
 	}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version2/RoadrunnerClawTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version2/RoadrunnerClawTest.java
@@ -1,17 +1,18 @@
-package org.firstinspires.ftc.teamcode.OpModes.Autonomous.Tests;
+package org.firstinspires.ftc.teamcode.OpModes.Autonomous.Tests.Version2;
 
 import com.acmerobotics.dashboard.FtcDashboard;
 import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
+import com.acmerobotics.roadrunner.SequentialAction;
+import com.acmerobotics.roadrunner.SleepAction;
 import com.acmerobotics.roadrunner.ftc.Actions;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
-import com.qualcomm.robotcore.hardware.PIDFCoefficients;
 
-import org.firstinspires.ftc.teamcode.Actions.Arm;
-import org.firstinspires.ftc.teamcode.Actions.Lift;
+import org.firstinspires.ftc.teamcode.Actions.Claw;
+import org.firstinspires.ftc.teamcode.Actions.Wrist;
 
 @Autonomous
-public class RoadrunnerLiftTest extends OpMode {
+public class RoadrunnerClawTest extends OpMode {
 	MultipleTelemetry multipleTelemetry;
 
 	@Override
@@ -25,7 +26,15 @@ public class RoadrunnerLiftTest extends OpMode {
 	@Override
 	public void start(){
 		Actions.runBlocking(
-				new Lift(hardwareMap, 10)
+				new SequentialAction(
+					new Claw(hardwareMap, 1),
+					new SleepAction(3),
+					new Wrist(hardwareMap, 1),
+					new SleepAction(3),
+					new Claw(hardwareMap, 0),
+					new SleepAction(3),
+					new Wrist(hardwareMap, 0)
+				)
 		);
 	}
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version2/RoadrunnerLiftTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version2/RoadrunnerLiftTest.java
@@ -1,19 +1,15 @@
-package org.firstinspires.ftc.teamcode.OpModes.Autonomous.Tests;
+package org.firstinspires.ftc.teamcode.OpModes.Autonomous.Tests.Version2;
 
 import com.acmerobotics.dashboard.FtcDashboard;
 import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
-import com.acmerobotics.roadrunner.SequentialAction;
-import com.acmerobotics.roadrunner.SleepAction;
 import com.acmerobotics.roadrunner.ftc.Actions;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
-import com.qualcomm.robotcore.hardware.PIDFCoefficients;
 
-import org.firstinspires.ftc.teamcode.Actions.Claw;
-import org.firstinspires.ftc.teamcode.Actions.Wrist;
+import org.firstinspires.ftc.teamcode.Actions.Lift;
 
 @Autonomous
-public class RoadrunnerClawTest extends OpMode {
+public class RoadrunnerLiftTest extends OpMode {
 	MultipleTelemetry multipleTelemetry;
 
 	@Override
@@ -27,15 +23,7 @@ public class RoadrunnerClawTest extends OpMode {
 	@Override
 	public void start(){
 		Actions.runBlocking(
-				new SequentialAction(
-					new Claw(hardwareMap, 1),
-					new SleepAction(3),
-					new Wrist(hardwareMap, 1),
-					new SleepAction(3),
-					new Claw(hardwareMap, 0),
-					new SleepAction(3),
-					new Wrist(hardwareMap, 0)
-				)
+				new Lift(hardwareMap, 10)
 		);
 	}
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version3/ShoulderTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version3/ShoulderTest.java
@@ -20,9 +20,9 @@ public class ShoulderTest extends OpMode {
 	public void start() {
 		Actions.runBlocking(
 				new SequentialAction(
-					action.shoulder(300),
+					action.shoulder(30),
 					action.hold(1),
-					action.shoulder(0)
+					action.shoulder(15)
 				)
 		);
 	}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version3/ShoulderTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autonomous/Tests/Version3/ShoulderTest.java
@@ -1,0 +1,34 @@
+package org.firstinspires.ftc.teamcode.OpModes.Autonomous.Tests.Version3;
+
+import com.acmerobotics.roadrunner.SequentialAction;
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
+
+import com.acmerobotics.roadrunner.ftc.Actions;
+import org.firstinspires.ftc.teamcode.Actions.Action;
+
+@Autonomous
+public class ShoulderTest extends OpMode {
+	private Action action;
+
+	@Override
+	public void init() {
+		this.action = new Action(hardwareMap, telemetry);
+	}
+
+	@Override
+	public void start() {
+		Actions.runBlocking(
+				new SequentialAction(
+					action.shoulder(300),
+					action.hold(1),
+					action.shoulder(0)
+				)
+		);
+	}
+
+	@Override
+	public void loop() {
+
+	}
+}


### PR DESCRIPTION
This pull request introduces the `Action` class, which provides an abstraction layer for controlling robot mechanisms like the lift, shoulder, claw, and wrist.

The `Action` class:
- Initializes motors and servos.
- Implements PID control for lift and shoulder movements.
- Provides methods to create `com.acmerobotics.roadrunner.Action`
  instances for individual mechanism movements (lift, shoulder,
  claw, wrist) and holds.
- Includes a `moveAndHold` method to continuously update motor power
  based on PID calculations.
- Integrates with FtcDashboard for telemetry.

Additionally, a `ShoulderTest` OpMode is added to demonstrate the usage of the `Action` class for controlling the shoulder mechanism.
